### PR TITLE
Remaining Dart 2 and over_react_codemod fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,17 @@ before_install:
   - sleep 3
 
 script:
+  - pub run build_runner build
   - pub run dart_dev format --check
-  - pub run dart_dev analyze
-  - pub serve --port=59925 test &
-  - sleep 5s
-  - pub run test --concurrency=4 -p content-shell --reporter=expanded --pub-serve=59925 test/unit/generated_runner_test.dart
-  - pub run dart_dev coverage --no-html
-  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov
+  # The analysis server can resolve elements from .dart_tool/build/, whereas the
+  # dartanalyzer cli cannot (yet). For this reason, tuneup is used because it
+  # leverages the analysis server. The dartanalyzer issue is being tracked here:
+  # https://github.com/dart-lang/sdk/issues/34098
+  - pub global activate tuneup
+  - pub global run tuneup check --ignore-infos
+  - pub run build_runner test -- --reporter=expanded
+  # dart_dev coverage is unsupported on Dart 2 for the time being.
+  # Long term, the hope is that coverage will be handled by the test package:
+  # https://github.com/dart-lang/test/issues/36
+  # - pub run dart_dev coverage --no-html
+  # - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,5 @@
+platforms:
+  - chrome
+
+paths:
+  - test/unit/generated_runner_test.dart

--- a/lib/src/todo_dart_react/actions.dart
+++ b/lib/src/todo_dart_react/actions.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of 'components.dart';
 
 class TodoActions {
   final Action<Todo> addTodo = new Action<Todo>();

--- a/lib/src/todo_dart_react/components.dart
+++ b/lib/src/todo_dart_react/components.dart
@@ -1,5 +1,3 @@
-library todo_dart_react;
-
 import 'dart:html';
 import 'dart:math';
 

--- a/lib/src/todo_dart_react/components/button.dart
+++ b/lib/src/todo_dart_react/components/button.dart
@@ -1,11 +1,10 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Nest one or more `Button` components within a [ListGroup]
 /// to render individual items within a list.
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/list-group/>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ButtonProps> Button = _$Button;
 
 @Props()

--- a/lib/src/todo_dart_react/components/button_group.dart
+++ b/lib/src/todo_dart_react/components/button_group.dart
@@ -1,10 +1,9 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Groups a series of [Button]s together on a single line.
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/button-group/>.
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ButtonGroupProps> ButtonGroup = _$ButtonGroup;
 
 @Props()

--- a/lib/src/todo_dart_react/components/list_group.dart
+++ b/lib/src/todo_dart_react/components/list_group.dart
@@ -1,11 +1,10 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Bootstrap's `ListGroup` component is flexible and powerful for
 /// displaying lists of [ListGroupItem] components.
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/list-group/>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ListGroupProps> ListGroup = _$ListGroup;
 
 @Props()

--- a/lib/src/todo_dart_react/components/list_group_item.dart
+++ b/lib/src/todo_dart_react/components/list_group_item.dart
@@ -1,11 +1,10 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Nest one or more `ListGroupItem` components within a [ListGroup]
 /// to render individual items within a list.
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/list-group/>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ListGroupItemProps> ListGroupItem = _$ListGroupItem;
 
 @Props()

--- a/lib/src/todo_dart_react/components/progress.dart
+++ b/lib/src/todo_dart_react/components/progress.dart
@@ -1,11 +1,10 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Bootstrap's `Progress` component stylizes the HTML5 `<progress>` element with a
 /// few extra CSS classes and some crafty browser-specific CSS.
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/progress/>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ProgressProps> Progress = _$Progress;
 
 @Props()
@@ -172,4 +171,3 @@ class ProgressSkin extends ClassNameConstant {
   /// [className] value: 'progress-info'
   static const ProgressSkin INFO = const ProgressSkin._('INFO', 'progress-info');
 }
-

--- a/lib/src/todo_dart_react/components/shared.dart
+++ b/lib/src/todo_dart_react/components/shared.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// A class of possible HTML `type` attribute values to be placed on a [Dom.button].
 class ButtonType extends DebugFriendlyConstant {
@@ -39,12 +39,7 @@ class ToggleBehaviorType extends DebugFriendlyConstant {
 }
 
 @PropsMixin()
-abstract class AbstractInputPropsMixin {
-  // To ensure the codemod regression checking works properly, please keep this
-  // field at the top of the class!
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const PropsMeta meta = _$metaForAbstractInputPropsMixin;
-
+abstract class _$AbstractInputPropsMixin {
   Map get props;
 
   /// The id for the input.
@@ -81,12 +76,7 @@ abstract class AbstractInputPropsMixin {
 }
 
 @StateMixin()
-abstract class AbstractInputStateMixin {
-  // To ensure the codemod regression checking works properly, please keep this
-  // field at the top of the class!
-  // ignore: undefined_identifier, undefined_class, const_initialized_with_non_constant_value
-  static const StateMeta meta = _$metaForAbstractInputStateMixin;
-
+abstract class _$AbstractInputStateMixin {
   Map get state;
 
   /// An auto-generated GUID, used as a fallback when the [AbstractInputPropsMixin.id] prop is unspecified,

--- a/lib/src/todo_dart_react/components/tag.dart
+++ b/lib/src/todo_dart_react/components/tag.dart
@@ -1,11 +1,10 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Bootstrap's `Tag` component renders a small and adaptive tag
 /// for adding context to just about any content.
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/tag/>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<TagProps> Tag = _$Tag;
 
 @Props()

--- a/lib/src/todo_dart_react/components/toggle_button.dart
+++ b/lib/src/todo_dart_react/components/toggle_button.dart
@@ -1,19 +1,14 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// Use [ToggleButton]s in order to render functional `<input type="checkbox">`
 /// or `<input type="radio">` elements that look like a [Button].
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ToggleButtonProps> ToggleButton = _$ToggleButton;
 
 @Props()
-class _$ToggleButtonProps extends ButtonProps
-    with
-        AbstractInputPropsMixin,
-        // ignore: mixin_of_non_class, undefined_class
-        $AbstractInputPropsMixin {
+class _$ToggleButtonProps extends ButtonProps with AbstractInputPropsMixin {
   /// Whether the `<input>` rendered by the [ToggleButton] should have focus upon mounting.
   ///
   /// _Proxies [DomProps.autoFocus]._
@@ -53,11 +48,7 @@ class _$ToggleButtonProps extends ButtonProps
 }
 
 @State()
-class _$ToggleButtonState extends ButtonState
-    with
-        AbstractInputStateMixin,
-        // ignore: mixin_of_non_class, undefined_class
-        $AbstractInputStateMixin {
+class _$ToggleButtonState extends ButtonState with AbstractInputStateMixin {
   /// Tracks if the [ToggleButton] is focused. Determines whether to render with the `js-focus` CSS
   /// class.
   ///
@@ -206,4 +197,3 @@ class ToggleButtonComponent extends ButtonComponent<ToggleButtonProps, ToggleBut
   /// [AbstractInputStateMixin.id] _(auto-generated)_.
   String get id => props.id ?? state.id;
 }
-

--- a/lib/src/todo_dart_react/components/toggle_button_group.dart
+++ b/lib/src/todo_dart_react/components/toggle_button_group.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 /// A specialized [ButtonGroup] component that will surround one or more child
 /// [ToggleButton] components so that a single shared [ToggleButtonGroupProps.name]
@@ -19,22 +19,13 @@ part of todo_dart_react;
 ///
 /// See: <http://v4-alpha.getbootstrap.com/components/buttons/#checkbox-and-radio-buttons>
 @Factory()
-// ignore: undefined_identifier
 UiFactory<ToggleButtonGroupProps> ToggleButtonGroup = _$ToggleButtonGroup;
 
 @Props()
-class _$ToggleButtonGroupProps extends ButtonGroupProps
-    with
-        AbstractInputPropsMixin,
-        // ignore: mixin_of_non_class, undefined_class
-        $AbstractInputPropsMixin {}
+class _$ToggleButtonGroupProps extends ButtonGroupProps with AbstractInputPropsMixin {}
 
 @State()
-class _$ToggleButtonGroupState extends ButtonGroupState
-    with
-        AbstractInputStateMixin,
-        // ignore: mixin_of_non_class, undefined_class
-        $AbstractInputStateMixin {}
+class _$ToggleButtonGroupState extends ButtonGroupState with AbstractInputStateMixin {}
 
 @Component(subtypeOf: ButtonGroupComponent)
 class ToggleButtonGroupComponent
@@ -99,4 +90,3 @@ class ToggleButtonGroupComponent
   @override
   UiFactory<ToggleButtonProps> get childFactory => ToggleButton;
 }
-

--- a/lib/src/todo_dart_react/model/todo.dart
+++ b/lib/src/todo_dart_react/model/todo.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 class Todo {
   String content;

--- a/lib/src/todo_dart_react/stores/todo_store.dart
+++ b/lib/src/todo_dart_react/stores/todo_store.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 class TodoStore extends Store {
   TodoStore(TodoActions actions) : _actions = actions {

--- a/lib/src/todo_dart_react/views/todo_app.dart
+++ b/lib/src/todo_dart_react/views/todo_app.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 @Factory()
 UiFactory<TodoAppProps> TodoApp = _$TodoApp;

--- a/lib/src/todo_dart_react/views/todo_input.dart
+++ b/lib/src/todo_dart_react/views/todo_input.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 @Factory()
 UiFactory<TodoInputProps> TodoInput = _$TodoInput;

--- a/lib/src/todo_dart_react/views/todo_list.dart
+++ b/lib/src/todo_dart_react/views/todo_list.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 typedef AddTodoCallback(Todo todo);
 typedef DeleteTodoCallback(Todo todo);

--- a/lib/src/todo_dart_react/views/todo_list_item.dart
+++ b/lib/src/todo_dart_react/views/todo_list_item.dart
@@ -1,4 +1,4 @@
-part of todo_dart_react;
+part of '../components.dart';
 
 @Factory()
 UiFactory<TodoListItemProps> TodoListItem = _$TodoListItem;

--- a/lib/todo_dart_react.dart
+++ b/lib/todo_dart_react.dart
@@ -1,5 +1,3 @@
 library todo_dart_react;
 
 export 'package:todo_dart_react/src/todo_dart_react/components.dart';
-// ignore: uri_has_not_been_generated
-part 'todo_dart_react.over_react.g.dart';


### PR DESCRIPTION
@leerob I ran the latest over_react_codemod (there were some leftover changes from an outdated version) and I also left off the `--backwards-compat` flag, which cleans up quite a few things.

Were you hoping to keep this example compatible with Dart 1 and 2? It is doable, but the backwards-compat component boilerplate is admittedly less enjoyable. For the purposes of this repo, it seems to me like it could be sufficient to point to our [Dart 2 migration guide](https://github.com/Workiva/over_react/blob/master/doc/dart2_migration.md) for those that are interested in retaining backwards-compatibility.

Let me know if you have any questions!

